### PR TITLE
feat ユーザー一覧での情報精度改善

### DIFF
--- a/backend/app/Http/Controllers/ShowHomeController.php
+++ b/backend/app/Http/Controllers/ShowHomeController.php
@@ -61,7 +61,9 @@ class ShowHomeController extends Controller
          * @var UserTimeline|null
          */
         $timelines = UserTimeline::with('User:id,name')->orderBy('start_date', 'desc')->take(10)->get();
-
+        foreach ($timelines as $timeline) {
+            $timeline->genreName = $timeline->genre->label();
+        }
         //お知らせは初回リリース未実装
         return view('home', ['userInfo' => $userInfo, 'userMajor' => $userMajor, 'userLiveArea' => $userLiveArea, 'userBirthArea' => $userBirthArea, 'userProjects' => $userProjects, 'timelines' => $timelines]);
     }

--- a/backend/app/Http/Controllers/User/ShowAllUserController.php
+++ b/backend/app/Http/Controllers/User/ShowAllUserController.php
@@ -34,16 +34,40 @@ class ShowAllUserController extends Controller
         $users = DB::table('user_infos')
             ->join('users', 'user_infos.user_id', '=', 'users.id')
             ->leftJoin('u_u_majors', 'user_infos.u_u_major_id', '=', 'u_u_majors.id')
-            ->select('users.id', 'users.name', 'users.profile_photo_path', 'user_infos.status', 'user_infos.last_name', 'user_infos.first_name', 'user_infos.grade', 'u_u_majors.name as uu_major', 'u_u_majors.faculty_id as uu_faculty')
+            ->select('users.id', 'users.name', 'users.profile_photo_path',   'user_infos.company_meta', 'user_infos.university_meta', 'user_infos.last_name', 'user_infos.first_name', 'user_infos.grade', 'u_u_majors.name as uu_major', 'u_u_majors.faculty_id as uu_faculty')
             ->orderBy('grade', 'asc') //後ほど学部順で使うため
             ->get();
 
+
         $listedUsers = [];
         foreach ($users as $user) {
+
+
+
             /**
-             * enmuを用いて学部を取得
+             * 社会人→会社名＋役職
+             * 他大生→学名＋学部＋学科
+             * 宇大生→学部＋学科
+             * (宇大生から社会人になった場合、宇大のデータが残っている可能性が否めないので、それ防止のために先に社会人から条件分岐させている)
              */
-            $user->uu_faculty = $user->uu_faculty == null ? "" : UUFaculty::from($user->uu_faculty)->label();
+
+            if ($user->company_meta) {
+                $company_meta = json_decode($user->company_meta);
+                $user->profession = $company_meta->company_name . " " . $company_meta->position;
+            } else if ($user->university_meta) {
+                $university_meta = json_decode($user->university_meta);
+                $user->profession = $university_meta->university . " " . $university_meta->faculty . " " . $university_meta->major;
+            } else if ($user->uu_faculty) {
+                /**
+                 * enmuを用いて学部を取得
+                 */
+                $user->uu_faculty =  UUFaculty::from($user->uu_faculty)->label();
+                $user->profession = $user->uu_faculty . " " . $user->uu_major;
+            } else {
+                //この場合は存在しないはずだがエラーになるのは困るので空文字
+                $user->profession = '';
+            }
+
 
             /**
              * 学年ごとに仕分けする

--- a/backend/resources/views/user/index.blade.php
+++ b/backend/resources/views/user/index.blade.php
@@ -16,10 +16,11 @@
     <a href="{{url('/user/'.$user->id)}}">
         <img src="{{url('/'.$user->profile_photo_path)}}" alt="">
         <p>{{$user->last_name}} {{$user->first_name}}({{$user->name}})</p>
+        @empty($user->satatus)
+        @else
         <p>{{$user->status}}</p>
-        @empty(!$user->uu_faculty)
-        <p>{{$user->uu_faculty}}/{{$user->uu_major}}</p>
         @endempty
+        <p>{{$user->profession}}</p>
     </a>
     @endforeach
     @endforeach


### PR DESCRIPTION
こういう感じ
![image](https://user-images.githubusercontent.com/63891531/156576081-1daa79b9-4c27-430e-8652-8c0e88744db4.png)

```php
        @empty(!$user->uu_faculty)
        <p>{{$user->uu_faculty}}/{{$user->uu_major}}</p>
        @endempty
```
を
```php
{{$user->profession}}
```
に