### PR TITLE
feat /security/update/emailの実装

### DIFF
--- a/backend/app/Http/Controllers/Security/UpdateEmailSecurityController.php
+++ b/backend/app/Http/Controllers/Security/UpdateEmailSecurityController.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Security;
 
 use App\Http\Controllers\Controller;
+use App\Models\User;
+use Auth;
 use Illuminate\Http\Request;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
@@ -16,8 +18,19 @@ class UpdateEmailSecurityController extends Controller
      *
      * @return Redirector|RedirectResponse
      */
-    public function __invoke(): Redirector|RedirectResponse
+    public function __invoke(Request $request): Redirector|RedirectResponse
     {
+        $userId = Auth::id();
+        /**
+         * バリデーション
+         */
+        $validateRule = [
+            'email' => 'required | email',
+            'email_confirm' => 'required | email | same:email',
+        ];
+        $this->validate($request, $validateRule);
+        /** emailを更新 */
+        User::where('id', $userId)->update(['email' => $request->email]);
         return redirect('/security');
     }
 }

--- a/backend/app/Http/Controllers/User/ShowEditUserController.php
+++ b/backend/app/Http/Controllers/User/ShowEditUserController.php
@@ -18,7 +18,6 @@ use App\Models\UserTimeline;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Auth;
 
 class ShowEditUserController extends Controller
 {
@@ -33,6 +32,16 @@ class ShowEditUserController extends Controller
 
         $user = User::where('id', $userId)->first();
 
+        /**
+         * @var UserInfo
+         * @property string $company_meta
+         * @property string $company
+         * @property string $position
+         * @property string $university_meta
+         * @property string $university
+         * @property string $faculty
+         * @property string $major
+         */
         $userInfo = UserInfo::where('user_id', $userId)->first();
 
         /**

--- a/backend/resources/views/security/index.blade.php
+++ b/backend/resources/views/security/index.blade.php
@@ -9,6 +9,15 @@
 {{-- inputタグのvalueに入れておく用 --}}
 @include('components.forMembers.pageSubTitle', ['subTitle'=>'セキュリティ情報変更'])
 <p class="text-sm xl:text-base px-2 mb-1 bg-bg rounded-full inline-block">メールアドレス</p>
+@if (count($errors) > 0)
+@error('email')
+<td style="color: red;">{{$message}}</td>
+@enderror
+@error('email_confirm')
+{{-- TODO:エラーメッセージなぜか赤色にならない 機能的には問題なし--}}
+<td class="text-red-600">※メールアドレスが一致していません</td>
+@enderror
+@endif
 <form method="POST" action="/security/update/email">
     @csrf
     <div class="flex flex-wrap items-center mb-2">


### PR DESCRIPTION
stan, testともに通過していないですがこちらで原因が判別できないためpushしました。
フロントのレイアウト(必須項目の*, 各ボタン周辺の余白)に改善の余地ありな感じですが、現状機能的に問題はありません。
また、メアド(確認用)が一致しない時のエラーメッセージが赤色にならないのですが、機能的に問題ないため後回しにしました。