### PR TITLE
feat /security/update/passwordの実装

### DIFF
--- a/backend/app/Http/Controllers/Security/UpdatePasswordSecurityController.php
+++ b/backend/app/Http/Controllers/Security/UpdatePasswordSecurityController.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Security;
 
 use App\Http\Controllers\Controller;
+use App\Models\User;
+use Auth;
+use Hash;
 use Illuminate\Http\Request;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
@@ -16,8 +19,21 @@ class UpdatePasswordSecurityController extends Controller
      *
      * @return Redirector|RedirectResponse
      */
-    public function __invoke(): Redirector|RedirectResponse
+    public function __invoke(Request $request): Redirector|RedirectResponse
     {
-        return redirect('/security');
+        $userId = Auth::id();
+        /**
+         * バリデーション
+         */
+        $validateRule = [
+            'password' => 'required | string | alpha_num | between:6,255',
+            'password_confirm' => 'required | string | same:password',
+        ];
+        $this->validate($request, $validateRule);
+        /** passwordをハッシュ化 */
+        $hashedPassword = Hash::make($request->password);
+        /** passwordを更新 */
+        User::where('id', $userId)->update(['password' => $hashedPassword]);
+        return redirect('/home');
     }
 }

--- a/backend/resources/views/security/index.blade.php
+++ b/backend/resources/views/security/index.blade.php
@@ -25,6 +25,14 @@
     </div>
 </form>
 <p class="text-sm xl:text-base px-2 mb-1 bg-bg rounded-full inline-block">パスワード</p>
+@if (count($errors) > 0)
+@error('password')
+<td>{{$message}}</td>
+@enderror
+@error('password_confirm')
+<td class="text-red-600">※パスワードが一致していません</td>
+@enderror
+@endif
 <form method="POST" action="/security/update/password">
     @csrf
     <div class="flex flex-wrap items-center mb-2">


### PR DESCRIPTION
パスワード変更後、/securityにリダイレクトすると再ログイン->/securityに入るための認証->/securityと連続で認証ページを通過しなければならなくなり、UX的にもパスワード変更後/securityに行きたい需要なさそうだと考えたため、パスワード変更後は/homeにリダイレクトするようにしました。都合悪いこととかあればもとに戻しても全然大丈夫です！